### PR TITLE
ウィンドウのタイトル名

### DIFF
--- a/PenguinBreak/PenguinBreak/App/scene/GameScene.cpp
+++ b/PenguinBreak/PenguinBreak/App/scene/GameScene.cpp
@@ -61,9 +61,11 @@ void GameScene::Update()
 			sceneManager_->SetNextScene(scene);
 		}
 	}
-
+	else
+	{//ゴールしたらプレイヤーが止まる処理
+		player->Update(stage);
+	}
 	stage->Update();
-	player->Update(stage);
 
 }
 void GameScene::Draw()

--- a/PenguinBreak/PenguinBreak/Library/base/Window.cpp
+++ b/PenguinBreak/PenguinBreak/Library/base/Window.cpp
@@ -19,7 +19,7 @@ void Window::CreateGameWindow()
 	//ウィンドウクラスの設定
 	m_w.cbSize = sizeof(WNDCLASSEX);
 	m_w.lpfnWndProc = (WNDPROC)WindowProce; // ウィンドウプロシージャを設定
-	m_w.lpszClassName = L"ペンギンブレーク"; // ウィンドウクラス名
+	m_w.lpszClassName = L"馬い棒"; // ウィンドウクラス名
 	m_w.hInstance = GetModuleHandle(nullptr); // ウィンドウハンドル
 	m_w.hCursor = LoadCursor(NULL, IDC_ARROW); // カーソル指定
 
@@ -30,7 +30,7 @@ void Window::CreateGameWindow()
 
 	// ウィンドウオブジェクトの生成
 	m_hwnd = CreateWindow(m_w.lpszClassName, // クラス名
-		L"ペンギンブレーク",         // タイトルバーの文字
+		L"馬い棒",         // タイトルバーの文字
 		WS_OVERLAPPEDWINDOW,        // 標準的なウィンドウスタイル
 		CW_USEDEFAULT,              // 表示X座標（OSに任せる）
 		CW_USEDEFAULT,              // 表示Y座標（OSに任せる）


### PR DESCRIPTION
ゴールしたらプレイヤーが動かないように変更